### PR TITLE
Add favicon and primary-200 color variable

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
             
             /* Primitive Colors - Primary */
             --primary-50: #EFF6FF;
+            --primary-200: #BFDBFE;
             --primary-500: #3B82F6;
             --primary-600: #2563EB;
             --primary-700: #1D4ED8;

--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gerador de Logos</title>
+    <link rel="icon" type="image/svg+xml" href="https://cdn.builder.io/api/v1/image/assets%2F7de6902bb7ea42d4be5082a42dd00e60%2F7842f03d96a34afdbd01ba80c1247f40?format=webp&width=800">
+    <link rel="icon" type="image/png" href="https://cdn.builder.io/api/v1/image/assets%2F7de6902bb7ea42d4be5082a42dd00e60%2Fff84044427a24c8aaecbb3e83e201577?format=webp&width=800">
+    <link rel="apple-touch-icon" href="https://cdn.builder.io/api/v1/image/assets%2F7de6902bb7ea42d4be5082a42dd00e60%2Fff84044427a24c8aaecbb3e83e201577?format=webp&width=800">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Purpose
Based on the conversation history, the user wanted to:
- Publish their logo generator page on the web
- Configure deployment on Netlify
- Add a favicon to improve the page's visual identity

## Code changes
- **Added favicon support**: Implemented multiple favicon formats (SVG, PNG, Apple Touch Icon) using Builder.io CDN assets
- **Enhanced color system**: Added `--primary-200` CSS variable (#BFDBFE) to expand the primary color palette

The favicon implementation includes fallback support for different browsers and devices, ensuring consistent branding across platforms.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6b5c2a67eccb4c29a0ccb01a1082bd45/echo-haven)

👀 [Preview Link](https://6b5c2a67eccb4c29a0ccb01a1082bd45-echo-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6b5c2a67eccb4c29a0ccb01a1082bd45</projectId>-->
<!--<branchName>echo-haven</branchName>-->